### PR TITLE
Fixup shell layout

### DIFF
--- a/src/components/shell/style.css
+++ b/src/components/shell/style.css
@@ -3,6 +3,7 @@
     background: linear-gradient(135deg, #f4f4f4, #f1f5f4);
     color: #2e3a4a;
     height: 100%;
+    box-sizing: border-box;
     display: flex;
     flex-flow: column;
     padding: 20px;

--- a/src/components/shell/style.css
+++ b/src/components/shell/style.css
@@ -1,7 +1,4 @@
 .host {
-    font-family: Roboto, 'Open Sans', 'Helvetica Neue', sans-serif;
-    background: linear-gradient(135deg, #f4f4f4, #f1f5f4);
-    color: #2e3a4a;
     height: 100%;
     box-sizing: border-box;
     display: flex;

--- a/src/styles/host.css
+++ b/src/styles/host.css
@@ -20,3 +20,9 @@ html, body, [data-app-root] {
     margin: 0;
     height: 100%;
 }
+
+html {
+    font-family: Roboto, 'Open Sans', 'Helvetica Neue', sans-serif;
+    background: #f4f4f4;
+    color: #2e3a4a;
+}


### PR DESCRIPTION
Since we're applying padding and height we need to use border-box layout, additionally to ensure overflow scrolling works correctly on mac (where the background should still appear within the over-scroll region) then we should apply the background as a solid colour and directly to the html element.