### PR TITLE
Tidyup redux state management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3538,26 +3538,6 @@
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
     },
-    "flux-standard-action": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/flux-standard-action/-/flux-standard-action-0.6.1.tgz",
-      "integrity": "sha1-bzQhG5SDTqHDzDD056+tPQ+/caI=",
-      "requires": {
-        "lodash.isplainobject": "3.2.0"
-      },
-      "dependencies": {
-        "lodash.isplainobject": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
-          "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
-          "requires": {
-            "lodash._basefor": "3.0.3",
-            "lodash.isarguments": "3.1.0",
-            "lodash.keysin": "3.0.8"
-          }
-        }
-      }
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -5787,11 +5767,6 @@
       "integrity": "sha1-GyCGwk8ATwdBG9sJt3UHIRS83cY=",
       "dev": true
     },
-    "lodash._basefor": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
-    },
     "lodash.assignin": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
@@ -5840,30 +5815,11 @@
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
       "dev": true
     },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
-    },
-    "lodash.keysin": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
-      "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
-      "requires": {
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
     },
     "lodash.map": {
       "version": "4.6.0",
@@ -7781,19 +7737,6 @@
       "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.2.3.tgz",
       "integrity": "sha1-GzrSmdqRy0G6MNaOO28CRHX7nhs=",
       "dev": true
-    },
-    "redux-promise": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/redux-promise/-/redux-promise-0.5.3.tgz",
-      "integrity": "sha1-6X5snTvzdurLebq+bZBtogES1tg=",
-      "requires": {
-        "flux-standard-action": "0.6.1"
-      }
-    },
-    "redux-thunk": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
-      "integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
     },
     "regenerate": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,7 @@
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
-    "redux-localstorage": "^0.4.1",
-    "redux-promise": "^0.5.3",
-    "redux-thunk": "^2.2.0"
+    "redux-localstorage": "^0.4.1"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/src/actions/ideas.js
+++ b/src/actions/ideas.js
@@ -1,60 +1,44 @@
 import { LIST_IDEAS, UPSERT_IDEA, REMOVE_IDEA } from '../constants/action-types';
 
-export const list = () => (dispatch, getState, { ideasService }) => {
+export const list = () => ({ ideasService }) => ({
+    type: LIST_IDEAS,
+    payload: ideasService.list(),
+});
 
-    dispatch({
-        type: LIST_IDEAS,
-        payload: ideasService.list(),
-    });
+export const create = (item, trackingKey, flush) => ({ ideasService }) => {
+
+    const payload = flush && ideasService.create(item);
+
+    return {
+        type: UPSERT_IDEA,
+        item,
+        trackingKey,
+        payload,
+    };
 
 };
 
-export const upsert = (item, entity, flush) => (dispatch, getState, { ideasService }) => {
+export const update = (item, entity, flush) => ({ ideasService }) => {
 
-    const type = UPSERT_IDEA;
+    const payload = flush && ideasService.update(entity.key, item);
 
-    if (flush) {
-
-        const payload = entity && entity.key
-            ? ideasService.update(entity.key, item)
-            : ideasService.create(item);
-
-        return dispatch({
-            type,
-            item,
-            entity,
-            payload,
-        });
-
-    }
-
-    dispatch({
-        type,
+    return {
+        type: UPSERT_IDEA,
         item,
         entity,
-    });
+        payload,
+    };
 
 };
 
-export const remove = (entity, flush) => (dispatch, getState, { ideasService }) => {
+export const remove = (entity, flush) => ({ ideasService }) => {
 
-    const type = REMOVE_IDEA;
+    const payload = flush && ideasService.remove(entity.key);
 
-    if (flush) {
-
-        const payload = ideasService.remove(entity.key);
-
-        return dispatch({
-            type,
-            entity,
-            payload,
-        });
-
-    }
-
-    dispatch({
-        type,
+    return {
+        type: REMOVE_IDEA,
         entity,
-    });
+        payload,
+    };
 
 };

--- a/src/actions/ideas.test.js
+++ b/src/actions/ideas.test.js
@@ -1,6 +1,6 @@
 import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 import sinon from 'sinon';
+import dependencies from '../store/depends-middleware';
 
 import { LIST_IDEAS, UPSERT_IDEA, REMOVE_IDEA } from '../constants/action-types';
 
@@ -9,7 +9,7 @@ import * as ideaActions from './ideas';
 const createMockStore = (deps = {}) => {
 
     const middleware = [
-        thunk.withExtraArgument(deps),
+        dependencies(deps),
     ];
 
     const mockStore = configureStore(middleware);
@@ -59,7 +59,7 @@ test('Invokes `ideasService.list` when invoking the list action', () => {
 
 });
 
-test('Dispatches an upsert action correctly for a non-flushing upsert', () => {
+test('Dispatches an upsert action correctly for a non-flushing update', () => {
 
     // arrange
     const item = {};
@@ -68,7 +68,7 @@ test('Dispatches an upsert action correctly for a non-flushing upsert', () => {
     const store = createMockStore();
 
     // act
-    store.dispatch(ideaActions.upsert(item, entity));
+    store.dispatch(ideaActions.update(item, entity));
 
     // assert
     expect(store.getActions()).toEqual([
@@ -77,7 +77,7 @@ test('Dispatches an upsert action correctly for a non-flushing upsert', () => {
 
 });
 
-test('Invokes `ideasService.create` when invoking the upsert action when flushing and no entity reference', () => {
+test('Invokes `ideasService.create` when invoking the create action when flushing', () => {
 
     // arrange
     const create = sinon.spy();
@@ -91,14 +91,14 @@ test('Invokes `ideasService.create` when invoking the upsert action when flushin
     const item = {};
 
     // act
-    store.dispatch(ideaActions.upsert(item, null, true));
+    store.dispatch(ideaActions.create(item, null, true));
 
     // assert
     expect(create.args).toEqual([[item]]);
 
 });
 
-test('Invokes `ideasService.update` when invoking the upsert action when flushing with an entity reference', () => {
+test('Invokes `ideasService.update` when invoking the update action when flushing', () => {
 
     // arrange
     const update = sinon.spy();
@@ -114,7 +114,7 @@ test('Invokes `ideasService.update` when invoking the upsert action when flushin
     const entity = { key };
 
     // act
-    store.dispatch(ideaActions.upsert(item, entity, true));
+    store.dispatch(ideaActions.update(item, entity, true));
 
     // assert
     expect(update.args).toEqual([[key, item]]);

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -7,17 +7,19 @@ import * as ideaViewActions from '../actions/ideas-view';
 import IdeasView from './ideas-view';
 import Shell from '../components/shell';
 
+const createRandomKey = () => Math.random().toString(16);
+
 const mapStateToProps = ({ ideasView }) => ({ ideasView });
 
 const mapDispatchToProps = ({
-    onUpsert: ideaActions.upsert,
+    onCreate: ideaActions.create,
     onSetSortType: ideaViewActions.setSortType,
     onSetSortDescending: ideaViewActions.setSortDescending,
 });
 
 class App extends React.Component {
 
-    handleCreate = () => this.props.onUpsert({ title: '' }, null, true) // TODO: remove empty title
+    handleCreate = () => this.props.onCreate({ title: '' }, createRandomKey(), true) // TODO: remove empty title
 
     render() {
 

--- a/src/containers/ideas-view.js
+++ b/src/containers/ideas-view.js
@@ -48,7 +48,7 @@ export class IdeasView extends React.Component {
             <IdeasListing>
                 {sorted.map(entity => (
                     <Idea
-                        key={entity.ephemeral}
+                        key={entity.trackingKey}
                         idea={entity.item}
                         issue={entity.error}
                         autofocus={entity.key == null}

--- a/src/containers/ideas-view.js
+++ b/src/containers/ideas-view.js
@@ -22,14 +22,14 @@ const mapStateToProps = ({ ideas, ideasView }) => ({ ideas, ideasView });
 
 const mapDispatchToProps = ({
     onList: ideaActions.list,
-    onUpsert: ideaActions.upsert,
+    onUpdate: ideaActions.update,
     onRemove: ideaActions.remove,
 });
 
 export class IdeasView extends React.Component {
 
-    handleChanging = entity => idea => this.props.onUpsert(idea, entity)
-    handleChanged = entity => idea => this.props.onUpsert(idea, entity, true)
+    handleChanging = entity => idea => this.props.onUpdate(idea, entity)
+    handleChanged = entity => idea => this.props.onUpdate(idea, entity, true)
     handleRemoved = entity => () => this.props.onRemove(entity, true)
 
     componentDidMount() {

--- a/src/containers/ideas-view.js
+++ b/src/containers/ideas-view.js
@@ -18,7 +18,11 @@ const comparers = new Map([
     [SORT_FIELD_TITLE, titleComparer],
 ]);
 
-const mapStateToProps = ({ ideas, ideasView }) => ({ ideas, ideasView });
+const mapStateToProps = ({ ideas, ideasView: { sortType, sortDescending } }) => ({
+    ideas,
+    sortType,
+    sortDescending,
+});
 
 const mapDispatchToProps = ({
     onList: ideaActions.list,
@@ -38,8 +42,7 @@ export class IdeasView extends React.Component {
 
     render() {
 
-        const { ideas, ideasView } = this.props;
-        const { sortType, sortDescending } = ideasView;
+        const { ideas, sortType, sortDescending } = this.props;
 
         const comparer = comparers.get(sortType);
         const sorted = ideas.slice(0).sort(sortDescending ? invertComparer(comparer) : comparer);

--- a/src/containers/ideas-view.test.js
+++ b/src/containers/ideas-view.test.js
@@ -11,11 +11,8 @@ test('Invokes onList when mounting', () => {
     const onList = sinon.spy();
 
     const ideas = [];
-    const ideasView = {
-        sorter: {},
-    };
 
-    const props = { ideas, ideasView, onList };
+    const props = { ideas, onList };
 
     // act
     mount(<IdeasView {...props} />);
@@ -25,22 +22,18 @@ test('Invokes onList when mounting', () => {
 
 });
 
-test('Invokes onUpsert with the change, entity and without flush when a child idea is changing', () => {
+test('Invokes onUpdate with the change, entity and without flush when a child idea is changing', () => {
 
     // arrange
-    const onUpsert = sinon.spy();
+    const onUpdate = sinon.spy();
 
     const entity = {
-        ephemeral: 1,
+        trackingKey: 1,
     };
 
     const ideas = [entity];
 
-    const ideasView = {
-        sorter: {},
-    };
-
-    const props = { ideas, ideasView, onUpsert };
+    const props = { ideas, onUpdate };
 
     const change = {};
 
@@ -50,26 +43,22 @@ test('Invokes onUpsert with the change, entity and without flush when a child id
     wrapper.find(Idea).props().onChanging(change);
 
     // assert
-    expect(onUpsert.args).toEqual([[change, entity]]);
+    expect(onUpdate.args).toEqual([[change, entity]]);
 
 });
 
-test('Invokes onUpsert with the change, entity and flush when a child idea has changed', () => {
+test('Invokes onUpdate with the change, entity and flush when a child idea has changed', () => {
 
     // arrange
-    const onUpsert = sinon.spy();
+    const onUpdate = sinon.spy();
 
     const entity = {
-        ephemeral: 1,
+        trackingKey: 1,
     };
 
     const ideas = [entity];
 
-    const ideasView = {
-        sorter: {},
-    };
-
-    const props = { ideas, ideasView, onUpsert };
+    const props = { ideas, onUpdate };
 
     const change = {};
 
@@ -79,7 +68,7 @@ test('Invokes onUpsert with the change, entity and flush when a child idea has c
     wrapper.find(Idea).props().onChanged(change);
 
     // assert
-    expect(onUpsert.args).toEqual([[change, entity, true]]);
+    expect(onUpdate.args).toEqual([[change, entity, true]]);
 
 });
 
@@ -89,16 +78,12 @@ test('Invokes onRemove with entity and flush when a child idea is removed', () =
     const onRemove = sinon.spy();
 
     const entity = {
-        ephemeral: 1,
+        trackingKey: 1,
     };
 
     const ideas = [entity];
 
-    const ideasView = {
-        sorter: {},
-    };
-
-    const props = { ideas, ideasView, onRemove };
+    const props = { ideas, onRemove };
 
     // act
     const wrapper = shallow(<IdeasView {...props} />);

--- a/src/store/async-middleware.test.js
+++ b/src/store/async-middleware.test.js
@@ -1,5 +1,4 @@
 import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
 import { STATUS_PENDING, STATUS_SUCCESS, STATUS_FAILURE } from '../constants/async-states';
 
@@ -9,7 +8,6 @@ test('Dispatches a successful async sequence for a resolved promise', async () =
 
     // arrange
     const middleware = [
-        thunk,
         asyncMiddleware,
     ];
 
@@ -36,7 +34,6 @@ test('Dispatches a failing async sequence for a rejected promise', async () => {
 
     // arrange
     const middleware = [
-        thunk,
         asyncMiddleware,
     ];
 

--- a/src/store/depends-middleware.js
+++ b/src/store/depends-middleware.js
@@ -1,0 +1,8 @@
+export default dependencies => () => next => maybeAction => {
+
+    const action = typeof maybeAction === 'function'
+        ? maybeAction(dependencies)
+        : maybeAction;
+
+    return next(action);
+};

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,13 +1,13 @@
 import { createStore, applyMiddleware, compose } from 'redux';
-import thunk from 'redux-thunk';
 
 import async from './async-middleware';
+import dependencies from './depends-middleware';
 import reducer from '../reducer';
 
 export default (deps, enhancers) => {
 
     const middleware = [
-        thunk.withExtraArgument(deps),
+        dependencies(deps),
         async,
     ];
 

--- a/src/utils/entity-manager.js
+++ b/src/utils/entity-manager.js
@@ -19,8 +19,6 @@ const createMap = (items, keySelector, valueSelector) => {
 
 };
 
-const createRandomKey = () => Math.random().toString(16);
-
 export default class EntityManager {
 
     constructor({ keySelector, dateSelector } = {}) {
@@ -40,7 +38,7 @@ export default class EntityManager {
                 const date = this.dateSelector(item);
                 const persistent = true;
                 const busy = false;
-                const ephemeral = createRandomKey();
+                const trackingKey = key;
 
                 const existingEntity = keyMap.get(key);
 
@@ -48,7 +46,7 @@ export default class EntityManager {
                     return entities;
                 }
 
-                const newEntity = { item, key, date, persistent, busy, ephemeral };
+                const newEntity = { item, trackingKey, key, date, persistent, busy };
 
                 return [...entities, newEntity];
 
@@ -97,9 +95,9 @@ export default class EntityManager {
             }
 
             const date = new Date();
-            const ephemeral = createRandomKey();
+            const trackingKey = action.trackingKey;
 
-            const newEntity = { item, key, date, flushing, busy, ephemeral, error };
+            const newEntity = { item, trackingKey, key, date, flushing, busy, error };
 
             return [...entities, newEntity];
 
@@ -108,7 +106,7 @@ export default class EntityManager {
         // otherwise this is an update to an already tracked entity
         return entities.map(entity => {
 
-            if (entity.ephemeral !== action.entity.ephemeral) return entity;
+            if (entity.trackingKey !== action.entity.trackingKey) return entity;
 
             const date = this.dateSelector(item);
 
@@ -125,7 +123,7 @@ export default class EntityManager {
 
         return entities.reduce((entities, entity) => {
 
-            if (entity.ephemeral !== action.entity.ephemeral) return [...entities, entity];
+            if (entity.trackingKey !== action.entity.trackingKey) return [...entities, entity];
 
             if (action.status === STATUS_SUCCESS) return entities;
 

--- a/src/utils/json-normalizing-visitor.js
+++ b/src/utils/json-normalizing-visitor.js
@@ -4,14 +4,6 @@ const isISODateString = str => /^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d(\.
 
 export default class JsonNormalizingVisitor extends JsonVisitor {
 
-    visitProperty({ key: currentKey, value }) {
-
-        const key = currentKey[0].toLowerCase() + currentKey.substring(1);
-
-        return super.visitProperty({ key, value });
-
-    }
-
     visitValue(value) {
 
         if (isISODateString(value)) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,22 +53,6 @@ export default ({ production, coverage, outputPath, appConfig } = {}) => {
         },
     ];
 
-    // const pwaManifest = new WebpackPwaManifest({
-    //     name: 'Ultra rare youtube app',
-    //     short_name: 'PreactTube',
-    //     description: 'The rarest of youtube apps',
-    //     background_color: '#eee',
-    //     theme_color: '#673ab8',
-    //     display: 'standalone',
-    //     start_url: '/',
-    //     icons: [{
-    //         src: path.resolve('meta/icon.png'),
-    //         sizes: [96, 128, 192, 256, 384, 512],
-    //     }],
-
-    //     inject: false,
-    // });
-
     const plugins = [
 
         new DefinePlugin({


### PR DESCRIPTION
- [x] minor tidyup of webpack config
- [x] minor tidyup of json normalization
- [x] minor changes to mapStateToProps in ideas view
- [x] remove `redux-thunk` - we want to avoid directly using dispatch within our action creators, we want middleware and the store itself to ultimately handle dispatching, thunk becomes an antipattern for us here, and we were only using it really for its ability to give a sort of _dependency injection_, instead we'll roll our own small middleware to allow action creators to take dependencies
- [x] simplify our idea actions by splitting upsert into create and update, these now have different signatures as creation also now requires a tracking key to be provided
- [x] we had an issue with our reducer previously where it would create random ephemeral keys itself, this removes the purity from the reducer as it is not deterministic, this could cause issues with debugging as state will not reproduce perfectly, instead now we shift the concept of ephemeral keys all the way to the invoker, in this case, our react/redux container